### PR TITLE
on_value and rules with same value are not exclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Basic number flag configuration using variables:
   "prerequisites": [],
   "rules": [
     {
-      "value": "${one}",
+      "value": "${five}",
       "expression": ""
     }
   ],

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Configuration structure:
 * `identifier` is unique configuration (flag) identifier
 * `deprecated` if true, than this configuration should be replaced with new configuration
 * `on` if true configuration is active otherwise it will serve always `off_value`
-* `on_value` when configuration is activated and all rules are failed then serve this value
 * `off_value` when `on` is false it will serve always this value
 * `prerequisites` check first dependencies on flag
 * `rules` array of two fields `expression` and `value`. Value can be one of the types: `string`, `number`, `object (JSON object)`, `array`, `boolean`, `null`. Expressions will be explained in next section.
@@ -113,10 +112,14 @@ Basic sample configuration:
   "identifier": "bool-flag",
   "deprecated": false,
   "on": true,
-  "on_value": true,
   "off_value": false,
   "prerequisites": [],
-  "rules": [],
+  "rules": [
+    {
+      "value": true,
+      "expression": ""
+    }
+  ],
   "version": 1
 }
 ```
@@ -131,10 +134,14 @@ Basic number flag configuration:
   "identifier": "number-flag",
   "deprecated": false,
   "on": true,
-  "on_value": 5,
   "off_value": 1,
   "prerequisites": [],
-  "rules": [],
+  "rules": [
+    {
+      "value": 5,
+      "expression": ""
+    }
+  ],
   "version": 1
 }
 ```
@@ -147,10 +154,14 @@ Basic number flag configuration using variables:
   "identifier": "number-flag",
   "deprecated": false,
   "on": true,
-  "on_value": "${five}",
   "off_value": "${one}",
   "prerequisites": [],
-  "rules": [],
+  "rules": [
+    {
+      "value": "${one}",
+      "expression": ""
+    }
+  ],
   "version": 1
 }
 ```
@@ -163,10 +174,14 @@ Basic string flag configuration:
   "identifier": "string-flag",
   "deprecated": false,
   "on": true,
-  "on_value": "item one",
   "off_value": "item two",
   "prerequisites": [],
-  "rules": [],
+  "rules": [
+    {
+      "value": "item one",
+      "expression": ""
+    }
+  ],
   "version": 1
 }
 ```
@@ -179,10 +194,14 @@ Basic array flag configuration:
   "identifier": "slice-flag",
   "deprecated": false,
   "on": true,
-  "on_value": ["item one", "item two", "item three","${success}"],
   "off_value": [],
   "prerequisites": [],
-  "rules": [],
+  "rules": [
+    {
+      "value": ["item one", "item two", "item three","${success}"],
+      "expression": ""
+    }
+  ],
   "version": 1
 }
 ```
@@ -195,13 +214,17 @@ Basic object flag configuration:
   "identifier": "number-flag",
   "deprecated": false,
   "on": true,
-  "on_value": {
-    "os": "linux",
-    "distro": "arch"
-  },
   "off_value": {},
   "prerequisites": [],
-  "rules": [],
+  "rules": [
+    {
+      "value": {
+        "os": "linux",
+        "distro": "arch"
+      },
+      "expression": ""
+    }
+  ],
   "version": 1
 }
 ```
@@ -214,10 +237,6 @@ Prerequisites flag configuration:
   "identifier": "number-flag",
   "deprecated": false,
   "on": true,
-  "on_value": {
-    "os": "linux",
-    "distro": "arch"
-  },
   "off_value": {},
   "prerequisites": [
     {
@@ -225,7 +244,15 @@ Prerequisites flag configuration:
       "value": true
     }
   ],
-  "rules": [],
+  "rules": [
+    {
+      "value": {
+        "os": "linux",
+        "distro": "arch"
+      },
+      "expression": ""
+    }
+  ],
   "version": 1
 }
 ```
@@ -240,7 +267,6 @@ it will serve true only if target identifier is equal to 'enver' otherwise it wi
   "identifier": "bool-flag",
   "deprecated": false,
   "on": true,
-  "on_value": false,
   "off_value": false,
   "prerequisites": [],
   "rules": [
@@ -262,7 +288,6 @@ Percentage rollout flag configuration:
   "identifier": "bool-flag",
   "deprecated": false,
   "on": true,
-  "on_value": false,
   "off_value": false,
   "prerequisites": [],
   "rules": [
@@ -292,7 +317,6 @@ Scheduled configurations
   "identifier": "bool-flag",
   "deprecated": false,
   "on": true,
-  "on_value": false,
   "off_value": false,
   "prerequisites": [],
   "rules": [
@@ -313,7 +337,6 @@ another example of scheduled flags:
   "identifier": "bool-flag",
   "deprecated": false,
   "on": true,
-  "on_value": false,
   "off_value": false,
   "prerequisites": [],
   "rules": [

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Basic sample configuration:
   "prerequisites": [],
   "rules": [
     {
-      "value": true,
+      "value": true, // default serve
       "expression": ""
     }
   ],
@@ -138,7 +138,7 @@ Basic number flag configuration:
   "prerequisites": [],
   "rules": [
     {
-      "value": 5,
+      "value": 5, // default serve
       "expression": ""
     }
   ],
@@ -158,7 +158,7 @@ Basic number flag configuration using variables:
   "prerequisites": [],
   "rules": [
     {
-      "value": "${five}",
+      "value": "${five}", // default serve
       "expression": ""
     }
   ],
@@ -178,7 +178,7 @@ Basic string flag configuration:
   "prerequisites": [],
   "rules": [
     {
-      "value": "item one",
+      "value": "item one", // default serve
       "expression": ""
     }
   ],
@@ -198,7 +198,7 @@ Basic array flag configuration:
   "prerequisites": [],
   "rules": [
     {
-      "value": ["item one", "item two", "item three","${success}"],
+      "value": ["item one", "item two", "item three","${success}"], // default serve
       "expression": ""
     }
   ],
@@ -218,7 +218,7 @@ Basic object flag configuration:
   "prerequisites": [],
   "rules": [
     {
-      "value": {
+      "value": { // default serve
         "os": "linux",
         "distro": "arch"
       },
@@ -246,7 +246,7 @@ Prerequisites flag configuration:
   ],
   "rules": [
     {
-      "value": {
+      "value": {  // default serve
         "os": "linux",
         "distro": "arch"
       },
@@ -278,6 +278,29 @@ it will serve true only if target identifier is equal to 'enver' otherwise it wi
   "version": 1
 }
 ```
+multivariate flag with some custom rule
+```json
+{
+  "project": "demo",
+  "environment": "dev",
+  "identifier": "bool-flag",
+  "deprecated": false,
+  "on": true,
+  "off_value": "item1",
+  "prerequisites": [],
+  "rules": [
+    {
+      "value": "item3",
+      "expression": "target.identifier == 'enver'"
+    },
+    {
+      "value": "item2", // default serve
+      "expression": ""
+    }
+  ],
+  "version": 1
+}
+```
 
 Percentage rollout flag configuration:
 
@@ -303,6 +326,10 @@ Percentage rollout flag configuration:
         }
       ],
       "expression": "target.identifier in beta_users"
+    },
+    {
+      "value": false, // default serve
+      "expression": ""
     }
   ],
   "version": 1
@@ -352,6 +379,10 @@ another example of scheduled flags:
         }
       ],
       "expression": "target.identifier in beta_users and now() >= date('2022-10-01')"
+    },
+    {
+      "value": false, // default serve
+      "expression": ""
     }
   ],
   "version": 1


### PR DESCRIPTION
Problem:
In prev design we had on_value but also in rules we can define same value with some rule and if that rule is evaluated false then engine will serve default on_value what is wrong it should serve oposite

```json
{
  "project": "demo",
  "environment": "dev",
  "identifier": "bool-flag",
  "deprecated": false,
  "on": true,
  "on_value": true,
  "off_value": false,
  "prerequisites": [],
  "rules": [
    {
      "value": true, // redeclaration with field on_value
      "expression": "target.identifier in beta"
    }
  ],
  "version": 1
}
```

Solution:
* on_value is removed
* when we define new rule with empty expression that means default serve on value.
for example if we have a flag bool-flag and on_value = true and in rules we put value: true with expression "target.identifier in beta" so flag will always serve true when it is turned on, why? Because if rule not passed then it will serve on_value and what people are doing put on_value to false and off_value to false. No need for this :)

```json
{
  "project": "demo",
  "environment": "dev",
  "identifier": "bool-flag",
  "deprecated": false,
  "on": true,
  "off_value": false,
  "prerequisites": [],
  "rules": [
    {
      "value": true, // default serve
      "expression": ""
    }
  ],
  "version": 1
}
```

if we have some rule then:

```json
{
  "project": "demo",
  "environment": "dev",
  "identifier": "bool-flag",
  "deprecated": false,
  "on": true,
  "off_value": false,
  "prerequisites": [],
  "rules": [
    {
      "value": true,
      "expression": "target.identifier in beta"
    }
  ],
  "version": 1
}
```
so if rule is not satisfied it will serve opposite value of rule in case of boolean flag, in multivariate flag default rule must exist